### PR TITLE
Add delete function to coupons

### DIFF
--- a/app/controllers/dashboard/coupons_controller.rb
+++ b/app/controllers/dashboard/coupons_controller.rb
@@ -13,16 +13,34 @@ class Dashboard::CouponsController < Dashboard::BaseController
       flash[:alert] = "You have reached your maximum of 5 coupons."
       redirect_to dashboard_coupons_path
     else
-      @merchant = current_user
       @coupon = Coupon.new
     end
   end
 
   def create
-    @merchant = current_user
-    @coupon = @merchant.coupons.new(coupon_params)
-    @coupon.save
-    redirect_to dashboard_coupons_path
+    @coupon = current_user.coupons.new(coupon_params)
+    @coupon.active = true
+    if @coupon.save
+      flash[:success] = "Your coupon has been added!"
+      redirect_to dashboard_coupons_path
+    else
+      flash[:danger] = @coupon.errors.full_messages
+      render :new
+    end
+  end
+
+  def destroy
+    @coupon = Coupon.find(params[:id])
+    if @coupon && @coupon.user == current_user
+      # if @coupon && @coupon.used?
+      #   flash[:error] = "You cannot delete this coupon."
+      # else
+        @coupon.destroy
+      # end
+      redirect_to dashboard_coupons_path
+    else
+      render file: 'public/404', status: 404
+    end
   end
 
   private

--- a/app/views/dashboard/coupons/new.html.erb
+++ b/app/views/dashboard/coupons/new.html.erb
@@ -1,6 +1,6 @@
 <h1>Enter New Coupon Information</h1>
 
-<%= form_for [@merchant, @coupon], url: dashboard_coupons_path do |f| %>
+<%= form_for @coupon, url: dashboard_coupons_path do |f| %>
   <p>
     <%= f.label :code %>
     <%= f.text_field :code %>

--- a/app/views/dashboard/coupons/show.html.erb
+++ b/app/views/dashboard/coupons/show.html.erb
@@ -5,7 +5,8 @@
 <p><%= link_to "Add New Coupon", new_dashboard_coupon_path %></p>
 
 <p><%= link_to "Edit Coupon" %></p>
-<p><%= link_to "Delete Coupon" %></p>
+<p><%= link_to "Delete Coupon", dashboard_coupon_path(@coupon), method: :delete  %></p>
+
 <% if @coupon.active? %>
   <p><%= link_to "Disable Coupon" %></p>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,10 +35,9 @@ Rails.application.routes.draw do
     patch '/items/:id/disable', to: 'items#disable', as: 'disable_item'
     put '/order_items/:order_item_id/fulfill', to: 'orders#fulfill', as: 'fulfill_order_item'
     resources :orders, only: [:show]
-    resources :coupons, only: [:index, :show, :new, :create]
-    resources :users, except: [:new, :create, :index, :show, :edit, :delete, :update] do
-      post '/coupons', to: 'coupons#create'
-    end
+    # resources :users, except: [:new, :create, :index, :show, :edit, :delete, :update] do
+    # post '/coupons', to: 'coupons#create'
+    resources :coupons, only: [:create, :index, :show, :new, :edit, :destroy]
   end
 
 

--- a/spec/features/merchants/coupon_show_spec.rb
+++ b/spec/features/merchants/coupon_show_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe "As a merchant" do
   before :each do
     @merchant = create(:merchant)
     @c1 = @merchant.coupons.create(code: "10OFF", discount: 0.10)
-    @c2 = @merchant.coupons.create(code: "10OFF", discount: 0.10, active: false)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    @c2 = @merchant.coupons.create(code: "25OFF", discount: 0.25, active: false)
+    @c6 = @merchant.coupons.create(code: "60OFF", discount: 0.60)
   end
 
   describe "when I visit the coupon show page" do
     it "my coupon is displayed" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c1)
 
       expect(current_path).to eq(dashboard_coupon_path(@c1))
@@ -18,6 +20,8 @@ RSpec.describe "As a merchant" do
     end
 
     it "has a Add New Coupon link" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c1)
 
       expect(current_path).to eq(dashboard_coupon_path(@c1))
@@ -26,6 +30,8 @@ RSpec.describe "As a merchant" do
     end
 
     it "when I click Add New Coupon I am directed to a form where I enter a new coupon and am returned to the index page and I see my new coupon" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c1)
 
       click_link "Add New Coupon"
@@ -39,6 +45,7 @@ RSpec.describe "As a merchant" do
       new_coupon = Coupon.last
 
       expect(current_path).to eq(dashboard_coupons_path)
+      expect(page).to have_content("Your coupon has been added!")
       expect(page).to have_content("Code: #{new_coupon.code}")
       expect(page).to have_content("Discount: #{new_coupon.discount*100}")
     end
@@ -47,6 +54,8 @@ RSpec.describe "As a merchant" do
       @c3 = @merchant.coupons.create(code: "10OFF", discount: 0.10)
       @c4 = @merchant.coupons.create(code: "40OFF", discount: 0.40, active: false)
       @c5 = @merchant.coupons.create(code: "50OFF", discount: 0.50, active: false)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
 
       visit dashboard_coupon_path(@c1)
 
@@ -57,6 +66,8 @@ RSpec.describe "As a merchant" do
     end
 
     it "has an Edit Coupon link" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c1)
 
       expect(current_path).to eq(dashboard_coupon_path(@c1))
@@ -65,14 +76,48 @@ RSpec.describe "As a merchant" do
     end
 
     it "has a Delete Coupon link" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c1)
 
       expect(current_path).to eq(dashboard_coupon_path(@c1))
       expect(page).to have_content(@c1.code)
-      expect(page).to have_link("Edit Coupon")
+      expect(page).to have_link("Delete Coupon")
+    end
+
+    xit "cannot Delete Coupon if coupon has been used" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
+      visit dashboard_coupon_path(@c6)
+
+      expect(current_path).to eq(dashboard_coupon_path(@c6))
+      expect(page).to have_content("You cannot delete this coupon.")
+      expect(page).to have_content(@c6.code)
+      expect(page).to_not have_link("Delete Coupon")
+    end
+
+    it "deletes a coupon when I click Delete Coupon link, I'm returned to the coupon index and do not see the deleted coupon" do
+      visit login_path
+
+      fill_in :email, with: @merchant.email
+      fill_in :password, with: @merchant.password
+
+      click_button "Log in"
+
+      visit dashboard_coupon_path(@c1)
+
+      expect(current_path).to eq(dashboard_coupon_path(@c1))
+      expect(page).to have_content(@c1.code)
+
+      click_on "Delete Coupon"
+
+      expect(current_path).to eq(dashboard_coupons_path)
+      expect(page).to_not have_content(@c1.code)
     end
 
     it "has a Disable Coupon link" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c1)
 
       expect(current_path).to eq(dashboard_coupon_path(@c1))
@@ -82,6 +127,8 @@ RSpec.describe "As a merchant" do
     end
 
     it "has an Enable Coupon link" do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
       visit dashboard_coupon_path(@c2)
 
       expect(current_path).to eq(dashboard_coupon_path(@c2))


### PR DESCRIPTION
- Remove sign in stub from coupon_show_spec, add login to individual tests
- Changed test to not look for delete button, but to check for deleted coupon content
- Update create method(remove @merchants references) in coupons_controller
- Add destroy method in coupons_controller
- Remove nesting from coupons new form
- Unnest coupons from users in dashboard namespace
- All tests passing, one skipped